### PR TITLE
Add the badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/martinwoodward/51afeda0-1964-48b1-a235-207522f4267d/9050091b-a36c-4428-bf18-ba5f072f198c/_apis/work/boardbadge/b9581fb5-f066-4390-89e4-57acdd0ae94f)](https://dev.azure.com/martinwoodward/51afeda0-1964-48b1-a235-207522f4267d/_boards/board/t/9050091b-a36c-4428-bf18-ba5f072f198c/Microsoft.RequirementCategory)
 # simpleweb
 Demo repo containing a super simple website
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#211](https://dev.azure.com/martinwoodward/51afeda0-1964-48b1-a235-207522f4267d/_workitems/edit/211). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.